### PR TITLE
Added node_options environment to kibana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .ssh-config
 .vagrant/*
 *~
+tests/.cache/
+__pycache__/

--- a/elasticsearch/kibana/map.jinja
+++ b/elasticsearch/kibana/map.jinja
@@ -3,7 +3,7 @@
         'config': {
             'elasticsearch_url': 'http://localhost:9200',
             'server.host': '127.0.0.1',
-            'server.port': '5601'
+            'server.port': 5601
         },
         'nginx_config': {
             'cert_path': '/etc/salt/ssl/certs/kibana.yourdomain.com.crt',
@@ -11,7 +11,10 @@
         },
         'nginx_extra_config_template_source': 'salt://elasticsearch/kibana/templates/nginx_extra.conf',
         'ssl_directory': '/etc/salt/ssl/certs',
-        'es_client_node': True
+        'es_client_node': True,
+        'kibana_env': [
+            'NODE_OPTIONS=--max-old-space-size=1024'
+        ]
     },
     'Debian': {
         'pkgs': [

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -45,7 +45,7 @@ def test_correct_heap_size(File, Command, SystemInfo):
     if distro in ['redhat', 'centos', 'fedora']:
         fname = File('/etc/sysconfig/elasticsearch')
         assert fname.exists
-    assert fname.contains('ES_HEAP_SIZE={0}m' .format(max_heap))
+    assert fname.contains('ES_HEAP_SIZE={0}m'.format(max_heap))
 
 
 def test_swappiness_set(Command, File):

--- a/tests/test_kibana.py
+++ b/tests/test_kibana.py
@@ -43,3 +43,12 @@ def test_nginx_running(File, Socket, Service):
 def test_ssl_directory(File):
     assert File('/etc/salt/ssl/certs').exists
     assert File('/etc/salt/ssl/certs').is_directory
+
+
+@pytest.mark.kibana
+def test_kibana_env(File, SystemInfo):
+    if SystemInfo.distribution == 'ubuntu':
+        f = File('/etc/init.d/kibana')
+    else:
+        f = File('/etc/systemd/system/kibana.service')
+    assert f.contains('NODE_OPTIONS=--max-old-space-size')


### PR DESCRIPTION
The Kibana server is routinely spking its memory usage and then getting
restarted by the OOM killer. In order to prvent this from happening it
is necessary to add a `NODE_OPTIONS` environment variable to pass a
`--max-old-space-size` flag to the node process.

Updated the state run to add this variable to the upstart or sytemd definitions.

closes mitodl/salt-ops#33
