### PR TITLE
Uncomment some settings in /etc/default/elasticsearch

### DIFF
--- a/elasticsearch/configure.sls
+++ b/elasticsearch/configure.sls
@@ -54,6 +54,11 @@ update_elasticsearch_heap_size:
         - service: elasticsearch
 {% endif %}
 
+uncomment_elasticsearch_defaults:
+  file.uncomment:
+    - name: {{ elasticsearch.env_file }}
+    - regex: (START_DAEMON|ES_USER|ES_GROUP|LOG_DIR|DATA_DIR|WORK_DIR|CONF_DIR|CONF_FILE|RESTART_ON_UPGRADE)
+
 # Configure/disable swappiness https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration-memory.html
 {% if elasticsearch.disable_swap %}
 disable_swap_on_elasticsearch_node:


### PR DESCRIPTION
#### What are the relevant tickets?

#### What's this PR do?
Elasticsearch service fails to start without uncommenting most of the settings in /etc/default/elasticsearch and this change uncomments those settings.
#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What gif best describes this PR or how it makes you feel?