### PR TITLE
Added a function to restart the service at the end of the configure r…

### DIFF
--- a/elasticsearch/configure.sls
+++ b/elasticsearch/configure.sls
@@ -121,3 +121,9 @@ set_elasticsearch_folder_permissions:
         - group
     - watch_in:
         - service: elasticsearch
+
+restart_elasticsearch_service:
+  service.running:
+    - name: elasticsearch
+    - restart: True
+


### PR DESCRIPTION
Added a function to restart the service at the end of the configure run. Service ends up in a weird (active but exited) state and having to restart the service manually once the salt run is complete.

#### What are the relevant tickets?

#### What's this PR do?
Forces a service restart at the end of the configure state.
#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What gif best describes this PR or how it makes you feel?